### PR TITLE
Rate-Limit feature based on UVCI

### DIFF
--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/pom.xml
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ch-covidcertificate-backend-transformation</artifactId>
+        <groupId>ch.admin.bag.covidcertificate</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ch-covidcertificate-backend-transformation-data</artifactId>
+    <name>CH Covidcertificate Backend Transformation Data</name>
+
+    <packaging>jar</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>ch.admin.bag.covidcertificate</groupId>
+            <artifactId>ch-covidcertificate-backend-transformation-model</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- database -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.15.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/data/RateLimitDataService.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/data/RateLimitDataService.java
@@ -1,0 +1,30 @@
+package ch.admin.bag.covidcertificate.backend.transformation.data;
+
+import ch.admin.bag.covidcertificate.backend.transformation.model.ratelimit.CurrentRate;
+import java.time.Duration;
+
+public interface RateLimitDataService {
+
+    /**
+     * Gets the current number of entries in the database for the given uvciHash
+     *
+     * @param uvciHash string for which to count the number of entries
+     * @return number of entries and the current string in a CurrentRate object
+     */
+    public CurrentRate getCurrentRate(String uvciHash);
+
+    /**
+     * Adds an entry to the database to indicate a rate-increase
+     *
+     * @param uvciHash identifier to use in the new entry
+     */
+    public void increaseRate(String uvciHash);
+
+    /**
+     * Removes all entries in the current database older than the given retentionperiod
+     *
+     * @param retentionperiod Duration indicating the amount of time an entry should be kept
+     * @return number of removed entries
+     */
+    public int cleanDB(Duration retentionperiod);
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/src/main/resources/db/migration/pgsql/V0_1__init.sql
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/src/main/resources/db/migration/pgsql/V0_1__init.sql
@@ -1,0 +1,13 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+CREATE TABLE t_rate_limit
+(
+    pk_rate_limit integer generated always as IDENTITY,
+    uvci_hash     Character varying(64)    NOT NULL,
+    created_at    timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT pk_t_rate_limit PRIMARY KEY (pk_rate_limit)
+);

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/src/main/resources/db/migration/pgsql_cluster/V0_1__init.sql
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-data/src/main/resources/db/migration/pgsql_cluster/V0_1__init.sql
@@ -1,0 +1,13 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+CREATE TABLE t_rate_limit
+(
+    pk_rate_limit integer generated always as IDENTITY,
+    uvci_hash     Character varying(64)    NOT NULL,
+    created_at    timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT pk_t_rate_limit PRIMARY KEY (pk_rate_limit)
+);

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/ratelimit/CurrentRate.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/ratelimit/CurrentRate.java
@@ -1,0 +1,23 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.ratelimit;
+
+public class CurrentRate {
+
+    private String uvciHash;
+    private int rate;
+
+    public String getUvciHash() {
+        return uvciHash;
+    }
+
+    public void setUvciHash(String uvciHash) {
+        this.uvciHash = uvciHash;
+    }
+
+    public int getRate() {
+        return rate;
+    }
+
+    public void setRate(int rate) {
+        this.rate = rate;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/controller/TransformationController.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/controller/TransformationController.java
@@ -81,12 +81,14 @@ public class TransformationController {
     @PostMapping(path = "/certificateLight")
     public @ResponseBody ResponseEntity<CertLightPayload> getCertLight(
             @Valid @RequestBody HCertPayload hCertPayload)
-            throws IOException, URISyntaxException, InterruptedException {
+            throws IOException, InterruptedException {
         // Decode and verify hcert
         final var dccHolder = verificationCheckClient.isValid(hCertPayload);
         if (dccHolder == null) {
             return ResponseEntity.badRequest().build();
         }
+
+        // TODO: Check rate-limit: Read UVCI, hash, read current rate, increase or interrupt
 
         // Create payload for qr light endpoint
         var euCert = dccHolder.getEuDGC();

--- a/ch-covidcertificate-backend-transformation/pom.xml
+++ b/ch-covidcertificate-backend-transformation/pom.xml
@@ -18,6 +18,8 @@
 
         <spring-boot-version>2.4.5</spring-boot-version>
         <spring-cloud-connectors-version>2.2.13.RELEASE</spring-cloud-connectors-version>
+        <jackson-version>2.11.1</jackson-version>
+        <testcontainers-version>1.15.2</testcontainers-version>
 
         <itCoverageAgent/>
 
@@ -37,6 +39,7 @@
         <module>ch-covidcertificate-backend-transformation-ws</module>
         <module>ch-covidcertificate-backend-transformation-model</module>
         <module>ch-covidcertificate-backend-transformation-report</module>
+        <module>ch-covidcertificate-backend-transformation-data</module>
     </modules>
 
     <dependencies>
@@ -131,7 +134,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
-           
+
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
We limit the number of allowed requests in a rolling 24-hour window by storing a timestamp for each request paired with the hash of the corresponding UVCI. We regularly refresh the database to remove any entries older than 24 hours.
If the rate limit has been reached, **TBD**