### PR TITLE
add pdf implementation

### DIFF
--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/BitPdfPayload.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/BitPdfPayload.java
@@ -1,0 +1,49 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+import java.time.Instant;
+
+public class BitPdfPayload {
+    private Long issuedAt;
+    private String hcert;
+    private DecodedCert decodedCert;
+    private String language;
+
+    public Long getIssuedAt() {
+        return issuedAt;
+    }
+
+    public void setIssuedAt(Instant issuedAt) {
+        this.issuedAt = issuedAt.toEpochMilli();
+    }
+
+    public void setIssuedAt(Long issuedAt) {
+        this.issuedAt = issuedAt;
+    }
+
+    public String getHcert() {
+        return hcert;
+    }
+
+    public void setHcert(String hcert) {
+        this.hcert = hcert;
+    }
+
+    public DecodedCert getDecodedCert() {
+        return decodedCert;
+    }
+
+    public void setDecodedCert(DecodedCert decodedCert) {
+        this.decodedCert = decodedCert;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(Language language) {
+        if (language == null) {
+            language = Language.getFallback();
+        }
+        this.language = language.name().toLowerCase();
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedCert.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedCert.java
@@ -1,0 +1,40 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+import ch.admin.bag.covidcertificate.backend.transformation.model.Person;
+
+public abstract class DecodedCert {
+
+    protected String dob;
+    protected Person nam;
+    protected String ver;
+
+    protected DecodedCert(String dob, Person nam, String ver) {
+        this.dob = dob;
+        this.nam = nam;
+        this.ver = ver;
+    }
+
+    public String getDob() {
+        return dob;
+    }
+
+    public void setDob(String dob) {
+        this.dob = dob;
+    }
+
+    public Person getNam() {
+        return nam;
+    }
+
+    public void setNam(Person nam) {
+        this.nam = nam;
+    }
+
+    public String getVer() {
+        return ver;
+    }
+
+    public void setVer(String ver) {
+        this.ver = ver;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedRCert.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedRCert.java
@@ -1,0 +1,17 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+import ch.admin.bag.covidcertificate.backend.transformation.model.Person;
+import java.util.List;
+
+public class DecodedRCert extends DecodedCert {
+    private List<RecoveryCert> r;
+
+    public DecodedRCert(String dob, Person nam, String ver, RecoveryCert r) {
+        super(dob, nam, ver);
+        this.r = List.of(r);
+    }
+
+    public List<RecoveryCert> getR() {
+        return r;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedTCert.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedTCert.java
@@ -1,0 +1,17 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+import ch.admin.bag.covidcertificate.backend.transformation.model.Person;
+import java.util.List;
+
+public class DecodedTCert extends DecodedCert {
+    private List<TestCert> t;
+
+    public DecodedTCert(String dob, Person nam, String ver, TestCert t) {
+        super(dob, nam, ver);
+        this.t = List.of(t);
+    }
+
+    public List<TestCert> getT() {
+        return t;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedVCert.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/DecodedVCert.java
@@ -1,0 +1,17 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+import ch.admin.bag.covidcertificate.backend.transformation.model.Person;
+import java.util.List;
+
+public class DecodedVCert extends DecodedCert {
+    private List<VaccinationCert> v;
+
+    public DecodedVCert(String dob, Person nam, String ver, VaccinationCert v) {
+        super(dob, nam, ver);
+        this.v = List.of(v);
+    }
+
+    public List<VaccinationCert> getV() {
+        return v;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/Language.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/Language.java
@@ -1,0 +1,28 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+import java.util.Locale;
+
+public enum Language {
+    DE,
+    FR,
+    IT,
+    RM;
+
+    public static Language forLocale(Locale locale) {
+        if (locale == null) {
+            return getFallback();
+        } else {
+            String code = locale.getLanguage();
+            for (Language language : Language.values()) {
+                if (language.name().equalsIgnoreCase(code)) {
+                    return language;
+                }
+            }
+        }
+        return getFallback();
+    }
+
+    public static Language getFallback() {
+        return DE;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/PdfResponse.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/PdfResponse.java
@@ -1,9 +1,11 @@
-package ch.admin.bag.covidcertificate.backend.transformation.model;
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
 
 import ch.ubique.openapi.docannotations.Documentation;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.validation.constraints.NotNull;
 
-public class PdfPayload {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PdfResponse {
 
     @Documentation(description = "Base-64-encoded covid certificate PDF")
     @NotNull

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/RecoveryCert.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/RecoveryCert.java
@@ -1,0 +1,71 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+/**
+ * This is a java implementation of the `recovery_entry` json spec found at
+ * https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/1.0.0/DGC.combined-schema.json
+ */
+public class RecoveryCert {
+    private String ci;
+    private String co;
+    private String df;
+    private String du;
+    private String fr;
+    private String is;
+    private String tg;
+
+    public String getCi() {
+        return ci;
+    }
+
+    public void setCi(String ci) {
+        this.ci = ci;
+    }
+
+    public String getCo() {
+        return co;
+    }
+
+    public void setCo(String co) {
+        this.co = co;
+    }
+
+    public String getDf() {
+        return df;
+    }
+
+    public void setDf(String df) {
+        this.df = df;
+    }
+
+    public String getDu() {
+        return du;
+    }
+
+    public void setDu(String du) {
+        this.du = du;
+    }
+
+    public String getFr() {
+        return fr;
+    }
+
+    public void setFr(String fr) {
+        this.fr = fr;
+    }
+
+    public String getIs() {
+        return is;
+    }
+
+    public void setIs(String is) {
+        this.is = is;
+    }
+
+    public String getTg() {
+        return tg;
+    }
+
+    public void setTg(String tg) {
+        this.tg = tg;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/TestCert.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/TestCert.java
@@ -1,0 +1,98 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+/**
+ * This is a java implementation of the `test_entry` json spec found at
+ * https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/1.0.0/DGC.combined-schema.json
+ */
+public class TestCert {
+    private String ci;
+    private String co;
+    private String is;
+    private String ma;
+    private String nm;
+    private String sc;
+    private String tc;
+    private String tg;
+    private String tr;
+    private String tt;
+
+    public String getCi() {
+        return ci;
+    }
+
+    public void setCi(String ci) {
+        this.ci = ci;
+    }
+
+    public String getCo() {
+        return co;
+    }
+
+    public void setCo(String co) {
+        this.co = co;
+    }
+
+    public String getIs() {
+        return is;
+    }
+
+    public void setIs(String is) {
+        this.is = is;
+    }
+
+    public String getMa() {
+        return ma;
+    }
+
+    public void setMa(String ma) {
+        this.ma = ma;
+    }
+
+    public String getNm() {
+        return nm;
+    }
+
+    public void setNm(String nm) {
+        this.nm = nm;
+    }
+
+    public String getSc() {
+        return sc;
+    }
+
+    public void setSc(String sc) {
+        this.sc = sc;
+    }
+
+    public String getTc() {
+        return tc;
+    }
+
+    public void setTc(String tc) {
+        this.tc = tc;
+    }
+
+    public String getTg() {
+        return tg;
+    }
+
+    public void setTg(String tg) {
+        this.tg = tg;
+    }
+
+    public String getTr() {
+        return tr;
+    }
+
+    public void setTr(String tr) {
+        this.tr = tr;
+    }
+
+    public String getTt() {
+        return tt;
+    }
+
+    public void setTt(String tt) {
+        this.tt = tt;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/VaccinationCert.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/pdf/VaccinationCert.java
@@ -1,0 +1,98 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model.pdf;
+
+/**
+ * This is a java implementation of the `vaccination_entry` json spec found at
+ * https://github.com/ehn-dcc-development/ehn-dcc-schema/blob/1.0.0/DGC.combined-schema.json
+ */
+public class VaccinationCert {
+    private String ci;
+    private String co;
+    private Integer dn;
+    private String dt;
+    private String is;
+    private String ma;
+    private String mp;
+    private Integer sd;
+    private String tg;
+    private String vp;
+
+    public String getCi() {
+        return ci;
+    }
+
+    public void setCi(String ci) {
+        this.ci = ci;
+    }
+
+    public String getCo() {
+        return co;
+    }
+
+    public void setCo(String co) {
+        this.co = co;
+    }
+
+    public Integer getDn() {
+        return dn;
+    }
+
+    public void setDn(Integer dn) {
+        this.dn = dn;
+    }
+
+    public String getDt() {
+        return dt;
+    }
+
+    public void setDt(String dt) {
+        this.dt = dt;
+    }
+
+    public String getIs() {
+        return is;
+    }
+
+    public void setIs(String is) {
+        this.is = is;
+    }
+
+    public String getMa() {
+        return ma;
+    }
+
+    public void setMa(String ma) {
+        this.ma = ma;
+    }
+
+    public String getMp() {
+        return mp;
+    }
+
+    public void setMp(String mp) {
+        this.mp = mp;
+    }
+
+    public Integer getSd() {
+        return sd;
+    }
+
+    public void setSd(Integer sd) {
+        this.sd = sd;
+    }
+
+    public String getTg() {
+        return tg;
+    }
+
+    public void setTg(String tg) {
+        this.tg = tg;
+    }
+
+    public String getVp() {
+        return vp;
+    }
+
+    public void setVp(String vp) {
+        this.vp = vp;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/pom.xml
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/pom.xml
@@ -229,22 +229,22 @@
                 <groupId>ch.ubique.openapi</groupId>
                 <artifactId>springboot-swagger-3</artifactId>
                 <configuration>
-                    <apiVersion>1.1.0</apiVersion>
+                    <apiVersion>2.2.0</apiVersion>
                     <basePackages>
-                        ch.admin.bag.covidcertificate.backend.exchange
+                        ch.admin.bag.covidcertificate.backend.transformation
                     </basePackages>
                     <controllers>
                         <controller>
                             ch.admin.bag.covidcertificate.backend.transformation.ws.controller.TransformationController
                         </controller>
                     </controllers>
-                    <description>CH Covidcertificate Exchange API</description>
+                    <description>CH Covidcertificate Transformation API</description>
                     <apiUrls>
                         <apiUrl>https://covidcertificate-app-d.bit.admin.ch</apiUrl>
                         <apiUrl>https://covidcertificate-app-a.bit.admin.ch</apiUrl>
                         <apiUrl>https://covidcertificate-app.bit.admin.ch</apiUrl>
                     </apiUrls>
-                    <title>CH Covidcertificate Exchange API</title>
+                    <title>CH Covidcertificate Transformation API</title>
                 </configuration>
             </plugin>
             <plugin>

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/pom.xml
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cloud-connectors</artifactId>
+            <version>${spring-cloud-connectors-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/pom.xml
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/pom.xml
@@ -134,6 +134,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -192,6 +198,12 @@
                     <mainClass>
                         ch.admin.bag.covidcertificate.backend.transformation.ws.TransformationWS
                     </mainClass>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                        </exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/TransformationWS.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/TransformationWS.java
@@ -12,12 +12,14 @@ package ch.admin.bag.covidcertificate.backend.transformation.ws;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @Configuration
 @ComponentScan(basePackages = {"ch.admin.bag.covidcertificate.backend.transformation.ws.config"})
+@ConfigurationPropertiesScan("ch.admin.bag.covidcertificate.backend.transformation.ws.config.model")
 @EnableAutoConfiguration
 @EnableWebMvc
 public class TransformationWS {

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/client/CertLightClient.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/client/CertLightClient.java
@@ -1,8 +1,8 @@
 package ch.admin.bag.covidcertificate.backend.transformation.ws.client;
 
 import ch.admin.bag.covidcertificate.backend.transformation.model.CertLightPayload;
-import ch.admin.bag.covidcertificate.backend.transformation.model.Person;
 import ch.admin.bag.covidcertificate.backend.transformation.model.TransformPayload;
+import ch.admin.bag.covidcertificate.backend.transformation.ws.util.DccHelper;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.util.OauthWebClient;
 import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.eu.DccCert;
 import ch.admin.bag.covidcertificate.sdk.core.verifier.nationalrules.ValidityRange;
@@ -15,16 +15,16 @@ import org.springframework.http.MediaType;
 
 public class CertLightClient {
 
-    private final String lightCertificateEnpoint;
+    private final String lightCertificateEndpoint;
     private final OauthWebClient oauthWebClient;
     private final ObjectMapper objectMapper;
     private final ZoneId verificationZoneId;
 
     public CertLightClient(
-            String lightCertificateEnpoint,
+            String lightCertificateEndpoint,
             OauthWebClient oauthWebClient,
             ZoneId verificationZoneId) {
-        this.lightCertificateEnpoint = lightCertificateEnpoint;
+        this.lightCertificateEndpoint = lightCertificateEndpoint;
         this.oauthWebClient = oauthWebClient;
         this.verificationZoneId = verificationZoneId;
         this.objectMapper = new ObjectMapper();
@@ -33,20 +33,12 @@ public class CertLightClient {
     public CertLightPayload getCertLight(DccCert euCert, ValidityRange validityRange)
             throws JsonProcessingException {
 
-        var name = euCert.getPerson();
-
-        var person = new Person();
-        person.setFn(name.getFamilyName());
-        person.setGn(name.getGivenName());
-        person.setFnt(name.getStandardizedFamilyName());
-        person.setGnt(name.getStandardizedGivenName());
-
         var expiry =
                 validityRange.getValidUntil().atZone(verificationZoneId).toInstant().toEpochMilli();
         var nowPlus48 = Instant.now().plus(Duration.ofHours(48)).toEpochMilli();
 
         var transformPayload = new TransformPayload();
-        transformPayload.setNam(person);
+        transformPayload.setNam(DccHelper.getPerson(euCert));
         transformPayload.setDob(euCert.getDateOfBirth());
         transformPayload.setExp(Math.min(expiry, nowPlus48));
 
@@ -55,7 +47,7 @@ public class CertLightClient {
                 oauthWebClient
                         .getWebClient()
                         .post()
-                        .uri(lightCertificateEnpoint)
+                        .uri(lightCertificateEndpoint)
                         .contentType(MediaType.APPLICATION_JSON)
                         .bodyValue(transformPayload)
                         .retrieve()

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/client/PdfClient.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/client/PdfClient.java
@@ -1,0 +1,52 @@
+package ch.admin.bag.covidcertificate.backend.transformation.ws.client;
+
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.BitPdfPayload;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedRCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedTCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedVCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.PdfResponse;
+import ch.admin.bag.covidcertificate.backend.transformation.ws.config.model.PdfConfig;
+import ch.admin.bag.covidcertificate.backend.transformation.ws.util.OauthWebClient;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+
+public class PdfClient {
+    private final PdfConfig pdfConfig;
+    private final OauthWebClient oauthWebClient;
+    private final ObjectMapper objectMapper;
+
+    public PdfClient(PdfConfig pdfConfig, OauthWebClient oauthWebClient) {
+        this.pdfConfig = pdfConfig;
+        this.oauthWebClient = oauthWebClient;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public PdfResponse getPdf(BitPdfPayload payload) throws JsonProcessingException {
+        DecodedCert decodedCert = payload.getDecodedCert();
+        String endpoint;
+        if (decodedCert instanceof DecodedTCert) {
+            endpoint = pdfConfig.getTestEndpoint();
+        } else if (decodedCert instanceof DecodedRCert) {
+            endpoint = pdfConfig.getRecoveryEndpoint();
+        } else if (decodedCert instanceof DecodedVCert) {
+            endpoint = pdfConfig.getVaccinationEndpoint();
+        } else {
+            throw new RuntimeException(
+                    "unexpected class received: " + decodedCert.getClass().getName());
+        }
+        var response =
+                oauthWebClient
+                        .getWebClient()
+                        .post()
+                        .uri(endpoint)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .bodyValue(payload)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .block();
+        return objectMapper.readValue(response, PdfResponse.class);
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/WsBaseConfig.java
@@ -13,7 +13,9 @@ package ch.admin.bag.covidcertificate.backend.transformation.ws.config;
 import ch.admin.bag.covidcertificate.backend.transformation.data.RateLimitDataService;
 import ch.admin.bag.covidcertificate.backend.transformation.data.impl.JdbcRateLimitDataServiceImpl;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.client.CertLightClient;
+import ch.admin.bag.covidcertificate.backend.transformation.ws.client.PdfClient;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.client.VerificationCheckClient;
+import ch.admin.bag.covidcertificate.backend.transformation.ws.config.model.PdfConfig;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.controller.TransformationController;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.service.RateLimitService;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.util.OauthWebClient;
@@ -46,7 +48,7 @@ public abstract class WsBaseConfig {
     private String mockUrl;
 
     @Value("${transform.light.endpoint}")
-    private String lightCertificateEnpoint;
+    private String lightCertificateEndpoint;
 
     @Value("${ws.jwt.client-id:default-client}")
     private String clientId;
@@ -72,9 +74,21 @@ public abstract class WsBaseConfig {
             VerificationCheckClient verificationCheckClient,
             CertLightClient certLightClient,
             RateLimitService rateLimitService,
+            PdfClient pdfClient,
+            PdfConfig pdfConfig,
             boolean debug) {
         return new TransformationController(
-                verificationCheckClient, certLightClient, rateLimitService, debug);
+                verificationCheckClient,
+                certLightClient,
+                rateLimitService,
+                pdfClient,
+                pdfConfig,
+                debug);
+    }
+
+    @Bean
+    public PdfClient pdfClient(OauthWebClient oauthWebClient, PdfConfig pdfConfig) {
+        return new PdfClient(pdfConfig, oauthWebClient);
     }
 
     @Bean
@@ -85,7 +99,7 @@ public abstract class WsBaseConfig {
     @Bean
     public CertLightClient certLightClient(
             OauthWebClient oauthWebClient, ZoneId verificationZoneId) {
-        return new CertLightClient(lightCertificateEnpoint, oauthWebClient, verificationZoneId);
+        return new CertLightClient(lightCertificateEndpoint, oauthWebClient, verificationZoneId);
     }
 
     @Bean

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/WsCloudConfig.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/WsCloudConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.backend.transformation.ws.config;
+
+import java.util.Map;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.CloudFactory;
+import org.springframework.cloud.service.PooledServiceConnectorConfig.PoolConfig;
+import org.springframework.cloud.service.relational.DataSourceConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("cloud")
+public class WsCloudConfig extends WsBaseConfig {
+
+    @Value("${datasource.maximumPoolSize:5}")
+    int dataSourceMaximumPoolSize;
+
+    @Value("${datasource.connectionTimeout:30000}")
+    int dataSourceConnectionTimeout;
+
+    @Value("${datasource.leakDetectionThreshold:0}")
+    int dataSourceLeakDetectionThreshold;
+
+    @Bean
+    @Override
+    public DataSource dataSource() {
+        PoolConfig poolConfig =
+                new PoolConfig(dataSourceMaximumPoolSize, dataSourceConnectionTimeout);
+        DataSourceConfig dbConfig =
+                new DataSourceConfig(
+                        poolConfig,
+                        null,
+                        null,
+                        Map.of("leakDetectionThreshold", dataSourceLeakDetectionThreshold));
+        CloudFactory factory = new CloudFactory();
+        return factory.getCloud().getSingletonServiceConnector(DataSource.class, dbConfig);
+    }
+
+    @Bean
+    @Override
+    public Flyway flyway() {
+        Flyway flyWay =
+                Flyway.configure()
+                        .dataSource(dataSource())
+                        .locations("classpath:/db/migration/pgsql_cluster")
+                        .load();
+        flyWay.migrate();
+        return flyWay;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/model/PdfConfig.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/model/PdfConfig.java
@@ -1,0 +1,44 @@
+package ch.admin.bag.covidcertificate.backend.transformation.ws.config.model;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "transform.pdf")
+public class PdfConfig {
+    private List<String> chIssuers;
+    private String testEndpoint;
+    private String recoveryEndpoint;
+    private String vaccinationEndpoint;
+
+    public List<String> getChIssuers() {
+        return chIssuers;
+    }
+
+    public void setChIssuers(List<String> chIssuers) {
+        this.chIssuers = chIssuers;
+    }
+
+    public String getTestEndpoint() {
+        return testEndpoint;
+    }
+
+    public void setTestEndpoint(String testEndpoint) {
+        this.testEndpoint = testEndpoint;
+    }
+
+    public String getRecoveryEndpoint() {
+        return recoveryEndpoint;
+    }
+
+    public void setRecoveryEndpoint(String recoveryEndpoint) {
+        this.recoveryEndpoint = recoveryEndpoint;
+    }
+
+    public String getVaccinationEndpoint() {
+        return vaccinationEndpoint;
+    }
+
+    public void setVaccinationEndpoint(String vaccinationEndpoint) {
+        this.vaccinationEndpoint = vaccinationEndpoint;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/util/DccHelper.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/util/DccHelper.java
@@ -1,5 +1,13 @@
 package ch.admin.bag.covidcertificate.backend.transformation.ws.util;
 
+import ch.admin.bag.covidcertificate.backend.transformation.model.Person;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedRCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedTCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedVCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.RecoveryCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.TestCert;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.VaccinationCert;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.client.exceptions.EmptyCertificateException;
 import ch.admin.bag.covidcertificate.backend.transformation.ws.client.exceptions.MultipleEntriesException;
 import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.eu.DccCert;
@@ -47,12 +55,107 @@ public class DccHelper {
                             .collect(Collectors.toList()));
         }
 
-        if (uvciList.isEmpty()) {
+        return getFirstAndAssert(uvciList);
+    }
+
+    /**
+     * Maps the given certificate to the format required for pdf export, asserting the certificate
+     * only contains a single entry
+     *
+     * @param dccCert Decoded and verified certificate as returned by verification-check
+     * @return DecodedCert
+     * @throws EmptyCertificateException if the certificate doesn't contain any entries
+     * @throws MultipleEntriesException if the certificate contains multiple entries
+     */
+    public static DecodedCert mapToDecodedCert(DccCert dccCert)
+            throws EmptyCertificateException, MultipleEntriesException {
+        String ver = dccCert.getVersion();
+        String dob = dccCert.getDateOfBirth();
+        Person nam = getPerson(dccCert);
+
+        final List<DecodedCert> mapped = new ArrayList<>();
+        if (dccCert.getVaccinations() != null) {
+            mapped.addAll(
+                    dccCert.getVaccinations().stream()
+                            .map(
+                                    v -> {
+                                        VaccinationCert vCert = new VaccinationCert();
+                                        vCert.setCi(v.getCertificateIdentifier());
+                                        vCert.setCo(v.getCountry());
+                                        vCert.setDn(v.getDoseNumber());
+                                        vCert.setDt(v.getVaccinationDate());
+                                        vCert.setIs(v.getCertificateIssuer());
+                                        vCert.setMa(v.getMarketingAuthorizationHolder());
+                                        vCert.setMp(v.getMedicinialProduct());
+                                        vCert.setSd(v.getTotalDoses());
+                                        vCert.setTg(v.getDisease());
+                                        vCert.setVp(v.getVaccine());
+
+                                        return new DecodedVCert(dob, nam, ver, vCert);
+                                    })
+                            .collect(Collectors.toList()));
+        }
+        if (dccCert.getTests() != null) {
+            mapped.addAll(
+                    dccCert.getTests().stream()
+                            .map(
+                                    t -> {
+                                        TestCert tCert = new TestCert();
+                                        tCert.setCi(t.getCertificateIdentifier());
+                                        tCert.setCo(t.getCountry());
+                                        tCert.setIs(t.getCertificateIssuer());
+                                        tCert.setMa(t.getRatTestNameAndManufacturer());
+                                        tCert.setNm(t.getNaaTestName());
+                                        tCert.setSc(t.getTimestampSample());
+                                        tCert.setTc(t.getTestCenter());
+                                        tCert.setTg(t.getDisease());
+                                        tCert.setTr(t.getResult());
+                                        tCert.setTt(t.getType());
+
+                                        return new DecodedTCert(dob, nam, ver, tCert);
+                                    })
+                            .collect(Collectors.toList()));
+        }
+        if (dccCert.getPastInfections() != null) {
+            mapped.addAll(
+                    dccCert.getPastInfections().stream()
+                            .map(
+                                    r -> {
+                                        RecoveryCert rCert = new RecoveryCert();
+                                        rCert.setCi(r.getCertificateIdentifier());
+                                        rCert.setCo(r.getCountryOfTest());
+                                        rCert.setDf(r.getValidFrom());
+                                        rCert.setDu(r.getValidUntil());
+                                        rCert.setFr(r.getDateFirstPositiveTest());
+                                        rCert.setIs(r.getCertificateIssuer());
+                                        rCert.setTg(r.getDisease());
+
+                                        return new DecodedRCert(dob, nam, ver, rCert);
+                                    })
+                            .collect(Collectors.toList()));
+        }
+
+        return getFirstAndAssert(mapped);
+    }
+
+    public static Person getPerson(DccCert dccCert) {
+        var name = dccCert.getPerson();
+        var person = new Person();
+        person.setFn(name.getFamilyName());
+        person.setGn(name.getGivenName());
+        person.setFnt(name.getStandardizedFamilyName());
+        person.setGnt(name.getStandardizedGivenName());
+        return person;
+    }
+
+    private static <T> T getFirstAndAssert(List<T> list)
+            throws EmptyCertificateException, MultipleEntriesException {
+        if (list.isEmpty()) {
             throw new EmptyCertificateException();
-        } else if (uvciList.size() > 1) {
+        } else if (list.size() > 1) {
             throw new MultipleEntriesException();
         } else {
-            return uvciList.get(0);
+            return list.get(0);
         }
     }
 }

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/util/PdfMapper.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/util/PdfMapper.java
@@ -1,0 +1,26 @@
+package ch.admin.bag.covidcertificate.backend.transformation.ws.util;
+
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.BitPdfPayload;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.Language;
+import ch.admin.bag.covidcertificate.backend.transformation.ws.client.exceptions.EmptyCertificateException;
+import ch.admin.bag.covidcertificate.backend.transformation.ws.client.exceptions.MultipleEntriesException;
+import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.CertificateHolder;
+import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.eu.DccCert;
+
+public class PdfMapper {
+    private PdfMapper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static BitPdfPayload mapToBitPayload(
+            CertificateHolder certificateHolder, Language language)
+            throws EmptyCertificateException, MultipleEntriesException {
+        var mapped = new BitPdfPayload();
+        mapped.setIssuedAt(certificateHolder.getIssuedAt());
+        mapped.setHcert(certificateHolder.getQrCodeData());
+        mapped.setDecodedCert(
+                DccHelper.mapToDecodedCert((DccCert) certificateHolder.getCertificate()));
+        mapped.setLanguage(language);
+        return mapped;
+    }
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/java/ch/admin/bag/covidcertificate/backend/transformation/ws/TestApplication.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/java/ch/admin/bag/covidcertificate/backend/transformation/ws/TestApplication.java
@@ -11,7 +11,9 @@
 package ch.admin.bag.covidcertificate.backend.transformation.ws;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication(
         scanBasePackages = {"ch.admin.bag.covidcertificate.backend.transformation.ws.config"})
+@ConfigurationPropertiesScan("ch.admin.bag.covidcertificate.backend.transformation.ws.config.model")
 public class TestApplication {}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/java/ch/admin/bag/covidcertificate/backend/transformation/ws/controller/TransformationControllerTest.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/java/ch/admin/bag/covidcertificate/backend/transformation/ws/controller/TransformationControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import ch.admin.bag.covidcertificate.backend.transformation.model.CertLightPayload;
 import ch.admin.bag.covidcertificate.backend.transformation.model.HCertPayload;
-import ch.admin.bag.covidcertificate.backend.transformation.model.PdfPayload;
+import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.PdfResponse;
 import ch.admin.bag.covidcertificate.backend.transformation.model.VerificationResponse;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.CheckNationalRulesState;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.CheckRevocationState;
@@ -61,7 +61,7 @@ class TransformationControllerTest extends BaseControllerTest {
     private static final String PDF_ENDPOINT = "/pdf";
     private static final String LIGHT_CERT_MOCK = "src/main/resources/light-cert-mock.json";
     private static CertLightPayload certLightMock;
-    private static PdfPayload mockPdfPayload;
+    private static PdfResponse mockPdfResponse;
 
     static {
         try {
@@ -73,8 +73,8 @@ class TransformationControllerTest extends BaseControllerTest {
                             .encodeToString(
                                     Files.readAllBytes(
                                             Paths.get("src/main/resources/cert-pdf-mock.pdf")));
-            mockPdfPayload = new PdfPayload();
-            mockPdfPayload.setPdf(pdfString);
+            mockPdfResponse = new PdfResponse();
+            mockPdfResponse.setPdf(pdfString);
         } catch (IOException e) {
             logger.error("Couldn't parse light cert mock file");
         }
@@ -173,7 +173,7 @@ class TransformationControllerTest extends BaseControllerTest {
                         .andReturn()
                         .getResponse();
         final var responsePayload =
-                objectMapper.readValue(response.getContentAsString(), PdfPayload.class);
-        assertEquals(mockPdfPayload.getPdf(), responsePayload.getPdf());
+                objectMapper.readValue(response.getContentAsString(), PdfResponse.class);
+        assertEquals(mockPdfResponse.getPdf(), responsePayload.getPdf());
     }
 }

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/resources/application-test.properties
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/resources/application-test.properties
@@ -13,3 +13,10 @@ mock.url=test
 transform.light.endpoint=http://test.transform.ch/v1/light
 verification.check.baseurl=http://test.verification.ch
 verification.check.endpoint=/v1/verify
+
+transform.pdf.test-endpoint=http://test.pdf.ch/api/v1/covidcertificate/fromexisting/test
+transform.pdf.recovery-endpoint=http://test.pdf.ch/api/v1/covidcertificate/fromexisting/recovery
+transform.pdf.vaccination-endpoint=http://test.pdf.ch/api/v1/covidcertificate/fromexisting/vaccination
+
+transform.pdf.chIssuers[0]=CH
+transform.pdf.chIssuers[1]=CH BAG

--- a/ch-covidcertificate-backend-transformation/pom.xml
+++ b/ch-covidcertificate-backend-transformation/pom.xml
@@ -31,7 +31,7 @@
         <sonar.organization>admin-ch</sonar.organization>
         <sonar.login>${env.SONAR_TOKEN}</sonar.login>
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/../ch-covidcertificate-backend-exchange-report/target/site/jacoco-aggregate/jacoco.xml
+            ${project.basedir}/../ch-covidcertificate-backend-transformation-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 


### PR DESCRIPTION
this pull request adds the implementation for the `/pdf` endpoint. valid certs with an issuer from switzerland are transformed into (base64 encoded) pdfs in the requested language. supported languages are `de`, `fr`, `it`, `rm`, with `de` as fallback