### PR TITLE
validate signature only for pdf request

### DIFF
--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/VerificationResponse.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/VerificationResponse.java
@@ -1,6 +1,7 @@
 package ch.admin.bag.covidcertificate.backend.transformation.model;
 
 import ch.admin.bag.covidcertificate.sdk.core.models.healthcert.CertificateHolder;
+import ch.admin.bag.covidcertificate.sdk.core.models.state.CheckSignatureState;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.VerificationState.ERROR;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.VerificationState.INVALID;
 import ch.admin.bag.covidcertificate.sdk.core.models.state.VerificationState.SUCCESS;
@@ -42,5 +43,18 @@ public class VerificationResponse {
 
     public void setInvalidState(INVALID invalidState) {
         this.invalidState = invalidState;
+    }
+
+    public boolean isValid() {
+        return successState != null;
+    }
+
+    public boolean signatureIsValid() {
+        return successState != null
+                || (errorState == null
+                        && (invalidState == null
+                                || invalidState.getSignatureState() == null
+                                || (invalidState.getSignatureState()
+                                        instanceof CheckSignatureState.SUCCESS)));
     }
 }

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/controller/TransformationController.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/controller/TransformationController.java
@@ -138,7 +138,7 @@ public class TransformationController {
             throws ValidationException, ResponseParseError, EmptyCertificateException,
                     MultipleEntriesException, JsonProcessingException {
         // Decode and verify hcert
-        final var validationResponse = verificationCheckClient.validate(hCertPayload);
+        final var validationResponse = verificationCheckClient.validateSignature(hCertPayload);
         final var certificateHolder = validationResponse.getHcertDecoded();
         if (certificateHolder == null || !chIssuers.contains(certificateHolder.getIssuer())) {
             return ResponseEntity.badRequest().build();


### PR DESCRIPTION
this pull request updates the certificate validation for the pdf export, so that only the signature is checked. this allows for pdf generation of certificates that are not yet or no longer valid, or are not valid due to national rules (in Switzerland) but could well be accepted by other countries.