### PR TITLE
Use separate endpoint to create PDFs for tourist vaccination certificates (suffix "_T")

### DIFF
--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/VaccinationCertificateTypes.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-model/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/model/VaccinationCertificateTypes.java
@@ -1,0 +1,5 @@
+package ch.admin.bag.covidcertificate.backend.transformation.model;
+
+public interface VaccinationCertificateTypes {
+  public static String VACCINATION_CERTIFICATE_TYPE_TOURIST_SUFFIX = "_T";
+}

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/client/PdfClient.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/client/PdfClient.java
@@ -1,6 +1,7 @@
 package ch.admin.bag.covidcertificate.backend.transformation.ws.client;
 
 import ch.admin.bag.covidcertificate.backend.transformation.model.TestTypes;
+import ch.admin.bag.covidcertificate.backend.transformation.model.VaccinationCertificateTypes;
 import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.BitPdfPayload;
 import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedCert;
 import ch.admin.bag.covidcertificate.backend.transformation.model.pdf.DecodedRCert;
@@ -35,7 +36,15 @@ public class PdfClient {
         } else if (decodedCert instanceof DecodedRCert) {
             endpoint = pdfConfig.getRecoveryEndpoint();
         } else if (decodedCert instanceof DecodedVCert) {
-            endpoint = pdfConfig.getVaccinationEndpoint();
+            if (((DecodedVCert) decodedCert)
+                .getV()
+                .get(0)
+                .getMp()
+                .endsWith(VaccinationCertificateTypes.VACCINATION_CERTIFICATE_TYPE_TOURIST_SUFFIX)) {
+                endpoint = pdfConfig.getVaccinationTouristEndpoint();
+            } else {
+                endpoint = pdfConfig.getVaccinationEndpoint();
+            }
         } else {
             throw new RuntimeException(
                     "unexpected class received: " + decodedCert.getClass().getName());

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/model/PdfConfig.java
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/java/ch/admin/bag/covidcertificate/backend/transformation/ws/config/model/PdfConfig.java
@@ -11,6 +11,8 @@ public class PdfConfig {
     private String vaccinationEndpoint;
     private String antibodyEndpoint;
 
+    private String vaccinationTouristEndpoint;
+
     public List<String> getChIssuers() {
         return chIssuers;
     }
@@ -50,4 +52,11 @@ public class PdfConfig {
     public void setAntibodyEndpoint(String antibodyEndpoint) {
         this.antibodyEndpoint = antibodyEndpoint;
     }
+
+    public String getVaccinationTouristEndpoint() { return vaccinationTouristEndpoint; }
+
+    public void setVaccinationTouristEndpoint(String vaccinationTouristEndpoint) {
+        this.vaccinationTouristEndpoint = vaccinationTouristEndpoint;
+    }
+
 }

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/resources/application-local.properties
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/main/resources/application-local.properties
@@ -18,6 +18,7 @@ verification.check.endpoint=/v1/verify
 transform.pdf.test-endpoint=http://localhost:8082/app/transform/v1/test
 transform.pdf.recovery-endpoint=http://localhost:8082/app/transform/v1/recovery
 transform.pdf.vaccination-endpoint=http://localhost:8082/app/transform/v1/vaccination
+transform.pdf.vaccination-tourist-endpoint=http://localhost:8082/app/transform/v1/vaccination-tourist
 transform.pdf.antibody-endpoint=http://localhost:8082/app/transform/v1/antibody
 
 transform.pdf.chIssuers[0]=CH

--- a/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/resources/application-test.properties
+++ b/ch-covidcertificate-backend-transformation/ch-covidcertificate-backend-transformation-ws/src/test/resources/application-test.properties
@@ -14,6 +14,8 @@ verification.check.endpoint=/v1/verify
 transform.pdf.test-endpoint=/app/transform/v1/test
 transform.pdf.recovery-endpoint=/app/transform/v1/recovery
 transform.pdf.vaccination-endpoint=/app/transform/v1/vaccination
+transform.pdf.vaccination-tourist-endpoint=/app/transform/v1/vaccination-tourist
+transform.pdf.antibody-endpoint=/app/transform/v1/antibody
 
 transform.pdf.chIssuers[0]=CH
 transform.pdf.chIssuers[1]=CH BAG


### PR DESCRIPTION
This pull-request makes sure we call the new endpoint of the management-service for creating PDFs of tourist vaccination certificates.