### PR TITLE
Renovate: update core SDK separately and skip dev versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,13 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
-      "groupName": "dependencies"
+      "groupName": "dependencies",
+      "excludePackageNames": ["ch.admin.bag.covidcertificate:sdk-core"]
+    },
+    {
+      "matchPackageNames": ["ch.admin.bag.covidcertificate:sdk-core"],
+      "allowedVersions": "!/.*-dev-.*/",
+      "groupName": "core-sdk"
     }
   ],
   "schedule": [


### PR DESCRIPTION
This PR tells Renovate to update the core SDK separately from other dependencies and to ignore dev versions